### PR TITLE
Updating openlayers version for IE11 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-      "angular": "~1.4.8",
-      "angular-sanitize": "~1.4.8",
+      "angular": "^1.4.8",
+      "angular-sanitize": "^1.4.8",
       "openlayers": "~3.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

We have currently a may rotation (slanting issue) with IE11 which upon using openlayers ~3.14 gets fixed.

"openlayers": "~3.14"

I am not having an access to push a branch, request for this update on package.json

Thank you.

Regards,
Serat Fatima
